### PR TITLE
Allow read-only text area to be copied

### DIFF
--- a/src/components/runs/InfoCard.vue
+++ b/src/components/runs/InfoCard.vue
@@ -94,7 +94,7 @@
             :options="{
               lineNumbers: true,
               mode: codeMirrorMode(tabItem.value),
-              readOnly: 'nocursor',
+              readOnly: true,
               tabSize: 2,
             }"
             :style="{

--- a/src/components/runs/LogCard.vue
+++ b/src/components/runs/LogCard.vue
@@ -75,7 +75,7 @@
             :options="{
               lineNumbers: true,
               mode: codeMirrorMode(tabItem.value),
-              readOnly: 'nocursor',
+              readOnly: true,
               lineWrapping: tabItem.key === 'Command',
               tabSize: 2,
             }"

--- a/src/components/services/InfoCard.vue
+++ b/src/components/services/InfoCard.vue
@@ -71,7 +71,7 @@
             :options="{
               lineNumbers: true,
               mode: codeMirrorMode(tabItem.value),
-              readOnly: 'nocursor',
+              readOnly: true,
               tabSize: 2,
             }"
             :style="{

--- a/src/components/services/RunImportDialog.vue
+++ b/src/components/services/RunImportDialog.vue
@@ -72,7 +72,7 @@
             lineNumbers: true,
             tabSize: 2,
             mode: codeMirrorMode(workflowContent),
-            readOnly: 'nocursor',
+            readOnly: true,
           }"
           :style="{
             outline: `solid 1px ${$colors.grey.lighten1}`,

--- a/src/components/services/WorkflowRegisterDialog.vue
+++ b/src/components/services/WorkflowRegisterDialog.vue
@@ -81,7 +81,7 @@
               lineNumbers: true,
               tabSize: 2,
               mode: codeMirrorMode(wfContentFetch),
-              readOnly: 'nocursor',
+              readOnly: true,
             }"
             :style="{
               outline: `solid 1px ${$colors.grey.lighten1}`,

--- a/src/components/workflows/InfoCard.vue
+++ b/src/components/workflows/InfoCard.vue
@@ -44,7 +44,7 @@
           lineNumbers: true,
           mode: codeMirrorMode(workflow.content),
           tabSize: 2,
-          readOnly: 'nocursor',
+          readOnly: true,
         }"
         :style="{
           outline: `solid 1px ${$colors.grey.lighten1}`,


### PR DESCRIPTION
Closes #33 

Apparently `nocursor` prevents the read-only text to be copied, but `true` keeps the read-only behaviour allowing the content to be copied.

https://discuss.codemirror.net/t/copy-text-to-clipboard-when-readonly-is-set-to-cursor/764

Tested locally.

-Bruno